### PR TITLE
Ticket 5414

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -19,7 +19,9 @@ from tests.settings import Settings
 from util.channel_access import ChannelAccessUtils
 from util.configurations import ConfigurationUtils, ComponentUtils
 from util.git_wrapper import GitUtils
+from util.gui import GuiUtils
 from util.synoptic import SynopticUtils
+from util.version import VersionUtils
 
 
 def run_instrument_tests(inst_name, reports_path):
@@ -77,7 +79,15 @@ def setup_instrument_tests(instrument):
         return False
 
     print("\n\nChecking out git repository for {} ({})...".format(name, hostname))
-    return GitUtils(Settings.config_repo_path).update_branch(hostname)
+    config_repo_update_successful = GitUtils(Settings.config_repo_path).update_branch(hostname)
+
+    version_utils = VersionUtils(Settings.config_repo_path)
+
+    if version_utils.version_file_exists():
+        GuiUtils(Settings.gui_repo_path).get_gui_repo_at_release(version_utils.get_version())
+    else:
+        print("Warning: could not determine GUI version for instrument {}".format(instrument))
+    return config_repo_update_successful
 
 
 def run_self_tests(reports_path):

--- a/run_tests.py
+++ b/run_tests.py
@@ -170,6 +170,17 @@ def main():
         if len(instruments) < len(args.instruments):
             raise ValueError("Some instruments specified could not be found in the instrument list.")
 
+## the following will exclude down instruments for testing
+## change instruments -> instruments_up in run_all_tests below
+#    inst_names = [x["name"] for x in instruments]
+#    inst_up = []
+#    for inst in inst_names:
+#        if ChannelAccessUtils("IN:{}:".format(inst)).get_value("CS:BLOCKSERVER:GET_CURR_CONFIG_DETAILS") is not None:
+#            inst_up.append(inst)
+#        else:
+#            print("Skipping {} as instrument down (no blockserver)".format(inst))
+#    instruments_up = [x for x in instruments if x["name"] in inst_up]
+
     reports_path = os.path.abspath(args.reports_path)
     Settings.set_repo_paths(os.path.abspath(args.configs_repo_path), os.path.abspath(args.gui_repo_path))
 

--- a/tests/synoptic_tests.py
+++ b/tests/synoptic_tests.py
@@ -27,8 +27,6 @@ class SynopticTests(unittest.TestCase):
         if not self.version_utils.version_file_exists():
             self.skipTest("Can't determine which version of the GUI is being used.")
 
-        self.gui_utils.get_gui_repo_at_release(self.version_utils.get_version())
-
     @skip_on_instruments(["DEMO"], "Demo often has a development version installed; this test is not useful")
     def test_GIVEN_synoptic_THEN_targets_that_it_defines_appear_in_opi_info(self):
 

--- a/util/channel_access.py
+++ b/util/channel_access.py
@@ -7,6 +7,10 @@ from enum import Enum
 from genie_python.genie_cachannel_wrapper import CaChannelWrapper
 from genie_python.channel_access_exceptions import UnableToConnectToPVException, ReadAccessException
 
+# Some instruments may not be available. If this is the case, we don't want to wait too long for the response which
+# will never come (which would slow down the tests)
+CHANNEL_ACCESS_TIMEOUT = 5
+
 
 class ChannelAccessUtils(object):
     """
@@ -22,7 +26,8 @@ class ChannelAccessUtils(object):
         :return: The PV value as a string, or None if there was an error
         """
         try:
-            return CaChannelWrapper.get_pv_value("{}{}".format(self.pv_prefix, pv, to_string=True))
+            return CaChannelWrapper.get_pv_value("{}{}".format(self.pv_prefix, pv, to_string=True),
+                                                 timeout=CHANNEL_ACCESS_TIMEOUT)
         except (UnableToConnectToPVException, ReadAccessException):
             return None
 

--- a/util/git_wrapper.py
+++ b/util/git_wrapper.py
@@ -46,3 +46,7 @@ class GitUtils(object):
             print("Git command failed. Error was: {}".format(e))
             return False
         return True
+
+    def fetch_all(self):
+        repo = git.Repo(path=self.path)
+        repo.git.fetch(all=True)


### PR DESCRIPTION
Speed up configchecker by:
- Only checking out the GUI repo at a particular release once, rather than once per synoptic
- Decreasing the channel access timeouts.

These two changes should result in the following performance increases:

Connected instrument with average number of synoptics: ~30s -> <2s
Disconnected instrument with average number of synoptics: ~60s -> 30s
Full run of all tests: ~45mins -> ~20 mins

https://github.com/ISISComputingGroup/IBEX/issues/5414