### PR TITLE
add ignored type for beamstop

### DIFF
--- a/util/synoptic.py
+++ b/util/synoptic.py
@@ -66,7 +66,7 @@ class SynopticUtils(object):
             return f.read()
 
     def type_should_be_ignored(self, type):
-        return type in ["UNKNOWN", "DAE"]
+        return type in ["UNKNOWN", "DAE", "BEAMSTOP"]
 
     def target_should_be_ignored(self, target):
         return target == "NONE"


### PR DESCRIPTION
Fix for IMAT. Beamstop is just a visual component, does not tie into a real OPI.