### PR TITLE
Ticket 6418 - Check for Device Screens

### DIFF
--- a/get_ioc_usage.py
+++ b/get_ioc_usage.py
@@ -99,7 +99,7 @@ def main():
                              "given instruments. If not defined, tests will be run on all instruments.")
     parser.add_argument("--ioc", type=str, default=None, help="If specified show instruments with IOC starting with"
                                                               "this string, otherwise show all iocs on the instruments")
-    parser.add_argument("--device_screens", help="Show if an instrument is missing an IOC",
+    parser.add_argument("--device_screens", help="Print device screens present on instrument/s",
                         action="store_true")
 
     args = parser.parse_args()

--- a/get_ioc_usage.py
+++ b/get_ioc_usage.py
@@ -40,7 +40,6 @@ def calc_iocs_on_intruments(instruments):
             # Instrument does not have device screen directory
             device_screens = []
 
-        instrument_name = instrument["name"]
         instrument_device_screens[instrument_name] = set(device_screens)
 
     return instrument_configs, instrument_device_screens

--- a/util/configurations.py
+++ b/util/configurations.py
@@ -160,7 +160,7 @@ class AbstractConfigurationUtils(object):
     def get_device_screens(self, xml):
         """
         Args:
-            xml: XML inout to parse
+            xml: XML input to parse
         Returns:
             device_screens (list): List of device screens
         """

--- a/util/configurations.py
+++ b/util/configurations.py
@@ -162,15 +162,11 @@ class AbstractConfigurationUtils(object):
         Args:
             xml: XML input to parse
         Returns:
-            device_screens (list): List of device screens
+            (set): Set of device screens
         """
         root = ET.fromstring(xml)
 
-        device_screens = []
-        for device in root:
-            device_screens.append(device.find(f"{self.DEVICES_XML_SCHEMA}key").text)
-
-        return set(device_screens)
+        return set({device.find(f"{self.DEVICES_XML_SCHEMA}key").text for device in root})
 
     def get_iocs_xml(self, config_name):
         """

--- a/util/configurations.py
+++ b/util/configurations.py
@@ -18,6 +18,7 @@ class AbstractConfigurationUtils(object):
     IOC_XML_SCHEMA = "{http://epics.isis.rl.ac.uk/schema/iocs/1.0}"
     COMPONENT_XML_SCHEMA = "{http://epics.isis.rl.ac.uk/schema/components/1.0}"
     BLOCK_XML_SCHEMA = "{http://epics.isis.rl.ac.uk/schema/blocks/1.0}"
+    DEVICES_XML_SCHEMA = "{http://epics.isis.rl.ac.uk/schema/screens/1.0/}"
 
     def __init__(self, config_repo_path):
         self.config_repo_path = config_repo_path
@@ -144,6 +145,33 @@ class AbstractConfigurationUtils(object):
         else:
             return pv_name
 
+    def get_devices_directory(self):
+        raise NotImplementedError("This is an abstract class, use a concrete class instead")
+
+    def get_device_screens_from_xml(self):
+        """
+        Gets the XML corresponding to the Device Screens for the instrument
+        Returns: the XML as a string
+        """
+        path = os.path.join(self.get_devices_directory(), "screens.xml")
+        with open(path) as xml_file:
+            return xml_file.read()
+
+    def get_device_screens(self, xml):
+        """
+        Args:
+            xml: XML inout to parse
+        Returns:
+            device_screens (list): List of device screens
+        """
+        root = ET.fromstring(xml)
+
+        device_screens = []
+        for device in root:
+            device_screens.append(device.find(f"{self.DEVICES_XML_SCHEMA}key").text)
+
+        return set(device_screens)
+
     def get_iocs_xml(self, config_name):
         """
         Gets the XML corresponding to the IOCs file for a particular configuration.
@@ -218,3 +246,11 @@ class ComponentUtils(AbstractConfigurationUtils):
 
     def get_configurations_directory(self):
         return os.path.join(self.config_repo_path, "configurations", "components")
+
+
+class DeviceUtils(AbstractConfigurationUtils):
+    """
+    Class containing the utility methods of interacting with the devices directory
+    """
+    def get_devices_directory(self):
+        return os.path.join(self.config_repo_path, "configurations", "devices")


### PR DESCRIPTION
Added the ability to check for which Device Screens are present on a given instrument.

A test, execute the `get_ioc_usage.bat --device_screens`, which will output the names of the Device Screens present on each instrument.

- Some instruments have no devices screens and as such the returned list will be empty
- Currently we only check the `devices.xml` but I have created another ticket for checking the Synoptic view entries
- Due to the way device screen configs are names, there is no easy way to compare them against an associated driver (i.e., large variance in names "Aldn100 Pump" versus "ALDN1000_01"). 