### PR TITLE
Add test to check for invalid block names

### DIFF
--- a/tests/configuration_tests.py
+++ b/tests/configuration_tests.py
@@ -168,9 +168,9 @@ class ConfigurationsTests(unittest.TestCase):
         for comp in components:
             blocks.extend(self.comp_utils.get_blocks(comp))
         
-        invalid_names = set([str(block) + " | len " + str(len(block)) for block in blocks if len(block) > 30])
+        invalid_names = set([str(block) + " | len " + str(len(block)) for block in blocks if len(block) > 25])
 
-        self.assertTrue(len(invalid_names) == 0, "Invalid block name length (> 30): {} , in configuration {}".format(invalid_names, self.config))
+        self.assertTrue(len(invalid_names) == 0, "Invalid block name length (> 25): {} , in configuration {}".format(invalid_names, self.config))
             
                         
     """ def test_GIVEN_a_configuration_THEN_it_does_not_contain_a_block_with_run_control_with_invalid_name_length(self):
@@ -181,23 +181,10 @@ class ConfigurationsTests(unittest.TestCase):
         for comp in components:
             blocks.extend(self.comp_utils.get_run_control_blocks(comp))
         
-        invalid_names = set([block for block in blocks if len(block) > 30])
+        invalid_names = set([str(block) + " | len " + str(len(block)) for block in blocks if len(block) > 25])
 
-        self.assertTrue(len(invalid_names) == 0, "Invalid block name(s) {} (longer than 30 characters), in configuration {}".format(invalid_names, self.config))
+        self.assertTrue(len(invalid_names) == 0, "Block with run control has invalid name length (> 25): {} , in configuration {}".format(invalid_names, self.config))
     """
 
-    """  def test_GIVEN_a_configuration_THEN_it_does_not_contain_a_block_with_invalid_name_length(self):
-        components = self.config_utils.get_active_components_as_list(self.config)
 
-        blocks = self.config_utils.get_blocks(self.config)
-
-        for comp in components:
-            blocks.extend(self.comp_utils.get_blocks(comp))
-
-        invalid_names = list([block for block in blocks if len(block) > 5])
-        invalid_lengths = list([len(block) for block in blocks if len(block) > 5])
-
-        self.assertTrue(len(invalid_names) == 0, "Invalid block name(s) {} of length {} (> 5 characters), in configuration {}".format(invalid_names, invalid_lengths, self.config))
-
-    """
      

--- a/tests/configuration_tests.py
+++ b/tests/configuration_tests.py
@@ -159,3 +159,16 @@ class ConfigurationsTests(unittest.TestCase):
 
         self.assertTrue(len(duplicates) == 0, "Case insensitive duplicate blocks found in {}: {}"
                         .format(self.config, duplicates))
+                        
+                        
+    def test_GIVEN_a_configuration_THEN_it_does_not_contain_a_block_with_run_control_with_invalid_name_length(self):
+        components = self.config_utils.get_active_components_as_list(self.config)
+
+        blocks = self.config_utils.get_run_control_blocks(self.config)
+        
+        for comp in components:
+            blocks.extend(self.comp_utils.get_run_control_blocks(comp))
+        
+        invalid_names = set([block for block in blocks if len(block) > 20])
+
+        self.assertTrue(len(invalid_names) == 0, "Invalid block name(s) {} (longer than 20 characters), in configuration {}".format(invalid_names, self.config))

--- a/tests/configuration_tests.py
+++ b/tests/configuration_tests.py
@@ -160,6 +160,7 @@ class ConfigurationsTests(unittest.TestCase):
         self.assertTrue(len(duplicates) == 0, "Case insensitive duplicate blocks found in {}: {}"
                         .format(self.config, duplicates))
 
+    @skip_on_instruments(["MERLIN", "LOQ", "EMU"], "Skip for now, legacy block.")
     def test_GIVEN_a_configuration_THEN_it_does_not_contain_a_block_with_invalid_name_length(self):
         components = self.config_utils.get_active_components_as_list(self.config)
 
@@ -169,22 +170,5 @@ class ConfigurationsTests(unittest.TestCase):
             blocks.extend(self.comp_utils.get_blocks(comp))
         
         invalid_names = set([str(block) + " | len " + str(len(block)) for block in blocks if len(block) > 25])
-
         self.assertTrue(len(invalid_names) == 0, "Invalid block name length (> 25): {} , in configuration {}".format(invalid_names, self.config))
-            
-                        
-    """ def test_GIVEN_a_configuration_THEN_it_does_not_contain_a_block_with_run_control_with_invalid_name_length(self):
-        components = self.config_utils.get_active_components_as_list(self.config)
-
-        blocks = self.config_utils.get_run_control_blocks(self.config)
-        
-        for comp in components:
-            blocks.extend(self.comp_utils.get_run_control_blocks(comp))
-        
-        invalid_names = set([str(block) + " | len " + str(len(block)) for block in blocks if len(block) > 25])
-
-        self.assertTrue(len(invalid_names) == 0, "Block with run control has invalid name length (> 25): {} , in configuration {}".format(invalid_names, self.config))
-    """
-
-
-     
+             

--- a/tests/configuration_tests.py
+++ b/tests/configuration_tests.py
@@ -159,9 +159,21 @@ class ConfigurationsTests(unittest.TestCase):
 
         self.assertTrue(len(duplicates) == 0, "Case insensitive duplicate blocks found in {}: {}"
                         .format(self.config, duplicates))
+
+    def test_GIVEN_a_configuration_THEN_it_does_not_contain_a_block_with_invalid_name_length(self):
+        components = self.config_utils.get_active_components_as_list(self.config)
+
+        blocks = self.config_utils.get_blocks(self.config)
+        
+        for comp in components:
+            blocks.extend(self.comp_utils.get_blocks(comp))
+        
+        invalid_names = set([str(block) + " | len " + str(len(block)) for block in blocks if len(block) > 30])
+
+        self.assertTrue(len(invalid_names) == 0, "Invalid block name length (> 30): {} , in configuration {}".format(invalid_names, self.config))
+            
                         
-                        
-    def test_GIVEN_a_configuration_THEN_it_does_not_contain_a_block_with_run_control_with_invalid_name_length(self):
+    """ def test_GIVEN_a_configuration_THEN_it_does_not_contain_a_block_with_run_control_with_invalid_name_length(self):
         components = self.config_utils.get_active_components_as_list(self.config)
 
         blocks = self.config_utils.get_run_control_blocks(self.config)
@@ -169,6 +181,23 @@ class ConfigurationsTests(unittest.TestCase):
         for comp in components:
             blocks.extend(self.comp_utils.get_run_control_blocks(comp))
         
-        invalid_names = set([block for block in blocks if len(block) > 20])
+        invalid_names = set([block for block in blocks if len(block) > 30])
 
-        self.assertTrue(len(invalid_names) == 0, "Invalid block name(s) {} (longer than 20 characters), in configuration {}".format(invalid_names, self.config))
+        self.assertTrue(len(invalid_names) == 0, "Invalid block name(s) {} (longer than 30 characters), in configuration {}".format(invalid_names, self.config))
+    """
+
+    """  def test_GIVEN_a_configuration_THEN_it_does_not_contain_a_block_with_invalid_name_length(self):
+        components = self.config_utils.get_active_components_as_list(self.config)
+
+        blocks = self.config_utils.get_blocks(self.config)
+
+        for comp in components:
+            blocks.extend(self.comp_utils.get_blocks(comp))
+
+        invalid_names = list([block for block in blocks if len(block) > 5])
+        invalid_lengths = list([len(block) for block in blocks if len(block) > 5])
+
+        self.assertTrue(len(invalid_names) == 0, "Invalid block name(s) {} of length {} (> 5 characters), in configuration {}".format(invalid_names, invalid_lengths, self.config))
+
+    """
+     

--- a/util/configurations.py
+++ b/util/configurations.py
@@ -132,21 +132,6 @@ class AbstractConfigurationUtils(object):
 
         return blocks
 
-    def get_run_control_blocks(self, config_name):
-        """
-        Returns a list of block names from blocks with run control.
-        :param config_name: the configuration name
-        :return: The list of block names.
-        """
-        root = ET.fromstring(self.get_blocks_xml(config_name))
-
-        blocks = []
-        for block in root.iter("{}block".format(self.BLOCK_XML_SCHEMA)):
-            if(block.find("{}rc_enabled".format(self.BLOCK_XML_SCHEMA)).text != "False"):
-                blocks.append(block.find("{}name".format(self.BLOCK_XML_SCHEMA)).text)
-
-        return blocks
-
     @staticmethod
     def _get_pv_name_without_field(pv_name):
         """

--- a/util/configurations.py
+++ b/util/configurations.py
@@ -132,6 +132,21 @@ class AbstractConfigurationUtils(object):
 
         return blocks
 
+    def get_run_control_blocks(self, config_name):
+        """
+        Returns a list of block names from blocks with run control.
+        :param config_name: the configuration name
+        :return: The list of block names.
+        """
+        root = ET.fromstring(self.get_blocks_xml(config_name))
+
+        blocks = []
+        for block in root.iter("{}block".format(self.BLOCK_XML_SCHEMA)):
+            if(block.find("{}rc_enabled".format(self.BLOCK_XML_SCHEMA)).text != "False"):
+                blocks.append(block.find("{}name".format(self.BLOCK_XML_SCHEMA)).text)
+
+        return blocks
+
     @staticmethod
     def _get_pv_name_without_field(pv_name):
         """


### PR DESCRIPTION
### Description
Added config test to check **all block names** are less than/equal to ~~20~~ **25 characters**. Test reports failed block name and the invalid length.

(See character limit justification here: https://github.com/ISISComputingGroup/EPICS-inst_servers/pull/368)

Added function to return all blocks from current config which have run control. Additional commented test for just checking run control enabled blocks if needed.

### Ticket:
https://github.com/ISISComputingGroup/IBEX/issues/3647