### PR TITLE
Remove all reference to six

### DIFF
--- a/tests/abstract_test_utils.py
+++ b/tests/abstract_test_utils.py
@@ -1,7 +1,6 @@
 from __future__ import print_function
 from __future__ import absolute_import
 import unittest
-import six
 
 from abc import ABCMeta, abstractmethod
 from .settings import Settings
@@ -9,8 +8,7 @@ from util.channel_access import ChannelAccessUtils
 from util.common import skip_on_instruments
 
 
-@six.add_metaclass(ABCMeta)
-class AbstractSingleTests(unittest.TestCase):
+class AbstractSingleTests(unittest.TestCase, metaclass=ABCMeta):
     """
     Abstract class for tests to be run exactly one regardless of how many components/configurations exist. It is meant
     to be extended by classes for configurations and for components.

--- a/tests/globals_tests.py
+++ b/tests/globals_tests.py
@@ -3,7 +3,6 @@ import unittest
 from .settings import Settings
 from util.globals import GlobalsUtils
 from util.common import CommonUtils, skip_on_instruments
-from six import string_types
 
 
 class GlobalsTests(unittest.TestCase):
@@ -20,7 +19,7 @@ class GlobalsTests(unittest.TestCase):
             self.skipTest("Globals file did not exist.")
 
         for linenumber, line in enumerate(self.globals_utils.get_lines(), 1):
-            self.assertIsInstance(line, string_types)
+            self.assertIsInstance(line, str)
             self.assertTrue(self.globals_utils.check_syntax(line),
                             "Invalid syntax on line {linenumber}. Line contents was: {contents}"
                             .format(linenumber=linenumber, contents=line))


### PR DESCRIPTION
### Description of work
Fix minor broken tests on master and then Remove all references to Six

### To test
[Ticket](https://github.com/ISISComputingGroup/IBEX/issues/8297)

### Acceptance criteria

- [x] Git grep finds no `import six`.
- [x] Tests pass