### PR TITLE
Corrected function to ignore checksum

### DIFF
--- a/util/version.py
+++ b/util/version.py
@@ -42,5 +42,5 @@ class VersionUtils(object):
 
     @staticmethod
     def extract_release_numbers_from_string(version: str) -> list[int]:
-        version_split = version.split(".")
+        version_split = version.split(".", maxsplit=3)[0:3]
         return [int(_x) for _x in version_split]


### PR DESCRIPTION
Extract version numbers function now ignores checksum part.