### PR TITLE
Check for old-style importer

### DIFF
--- a/run_tests.bat
+++ b/run_tests.bat
@@ -4,6 +4,7 @@ REM Define working directories
 set "configs_dir=%~dp0configs"
 set "gui_dir=%~dp0gui"
 set "reports_dir=%~dp0test-reports"
+set "python_dir=C:\Instrument\Apps\Python3"
 
 REM Clone necessary repositories
 REM Do this here rather than in python because it will make git authentication dialogs visible rather than being in a python thread.
@@ -19,7 +20,7 @@ if exist "%reports_dir%" (
     rd /s /q "%reports_dir%"
 )
 
-call %~dp0Python3\genie_python3.bat -u run_tests.py --configs_repo_path "%configs_dir%" --gui_repo_path "%gui_dir%" --reports_path "%reports_dir%"
+call %python_dir%\genie_python3.bat -u run_tests.py --configs_repo_path "%configs_dir%" --gui_repo_path "%gui_dir%" --reports_path "%reports_dir%"
 if %errorlevel% neq 0 (
     @echo ERROR: genie_python3.bat exited with code %errorlevel%
     exit /b %errorlevel%

--- a/tests/scripting_directory_tests.py
+++ b/tests/scripting_directory_tests.py
@@ -61,3 +61,18 @@ class ScriptingDirectoryTests(unittest.TestCase):
             self._directory_contains_compiled_files(self.inst_directory),
             "Instrument scripts directory contained compiled files",
         )
+
+    def test_GIVEN_inst_scripts_dir_exists_THEN_it_doesnt_contain_old_style_importer(self):
+        init = os.path.join(self.inst_directory, "__init__.py")
+        if not os.path.exists(init):
+            self.skipTest("No inst\\__init__.py found")
+
+        with open(init) as f:
+            text = f.read()
+
+        if "import pkgutil" in text:
+            self.fail(
+                "Instrument scripts directory contained old-style 'from * import *' code. "
+                "This doesn't work with Python 3.12, or with pyright. "
+                "It should be migrated to standard python imports."
+            )


### PR DESCRIPTION
This fails on a few instruments (some of which it's just commented out, the others haven't had pyright deployed yet)

This at least flags them so we know which ones we need to go and fix.

Reviewer: if happy, create a task to merge this & fix in the upcoming shutdown rather than merging straight away