### PR TITLE
Test run number length

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -13,6 +13,7 @@ from xmlrunner import XMLTestRunner
 
 from tests.component_tests import ComponentsSingleTests, ComponentsTests
 from tests.configuration_tests import ConfigurationsSingleTests, ConfigurationsTests
+from tests.dae_tests import DaeTests
 from tests.globals_tests import GlobalsTests
 from tests.motor_tests import MotorTests
 from tests.scripting_directory_tests import ScriptingDirectoryTests
@@ -45,6 +46,7 @@ def run_instrument_tests(inst_name, reports_path):
         ConfigurationsSingleTests,
         ComponentsSingleTests,
         MotorTests,
+        DaeTests,
     ]:
         suite.addTests(loader.loadTestsFromTestCase(case))
 

--- a/tests/dae_tests.py
+++ b/tests/dae_tests.py
@@ -1,0 +1,31 @@
+import concurrent.futures
+import unittest
+
+from tests.settings import Settings
+from util.channel_access import ChannelAccessUtils
+
+
+class DaeTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.ca = ChannelAccessUtils(Settings.pv_prefix)
+
+    def test_dae_run_number_digits_suffecient(self) -> None:
+        """
+        Check if the current run number is close to exceeding the available number of digits.
+
+        We define the number of digits in the run number in C:\Instrument\Settings\labview modules\dae\icp_config.xml
+        It is easier to simply access the current run number and check the nuber of digits in against the current number
+        than to check this xml.
+        """
+        failure_threshold_percent = 90
+        current_run_number = self.ca.get_value("DAE:RUNNUMBER")
+
+        # current_run_number will be none if instrument off
+        if current_run_number is None:
+            self.skipTest("No run number, likely instrument is off")
+
+        with self.subTest():
+            self.assertGreater(
+                failure_threshold_percent/100*(10**len(current_run_number)),
+                int(current_run_number),
+                f"The current run number is within {failure_threshold_percent}% ({100*int(current_run_number)/(10**len(current_run_number)):.1f}%)of the maximum run number")


### PR DESCRIPTION
Add a test as t whether the current run number is getting within 90% of the maximum configured run number