### PR TITLE
fix instrumentchecker by using mysql-connector-python<9.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   "parameterized",
   "CaChannel@git+https://github.com/ISISComputingGroup/CaChannel",
   "gitpython",
-  "mysql-connector-python != 9.6.0",  # 9.6.0 release is broken - missing wheels on pypi
+  "mysql-connector-python < 9.6.0",  # 9.6.0+ release is broken - missing wheels on pypi
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
9.7.0 also doesn't have any wheels... 