### PR TITLE
Remove ERROR from parse_rules

### DIFF
--- a/parse_rules
+++ b/parse_rules
@@ -1,4 +1,3 @@
-error /FAILED \(errors=/
-error /FAILED \(failures=/
+error /FAIL \[/
 warning /(?i)^(\[[^]]*\] )?warning:?/
 info /(?i)^(\[[^]]*\] )?info:?/

--- a/parse_rules
+++ b/parse_rules
@@ -1,6 +1,3 @@
-# allow for [timestamp]
-error /(?i)^(\[[^]]*\] )?error:/
-error /(?i)^(\[[^]]*\] )?fatal:/
 error /FAILED \(errors=/
 error /FAILED \(failures=/
 warning /(?i)^(\[[^]]*\] )?warning:?/


### PR DESCRIPTION
ie. https://epics-jenkins.isis.rl.ac.uk/job/InstrumentChecker/3447/parsed_console/ 

where FAILED is the only actual useful information and the process returns 1 anyway if it falls over. 